### PR TITLE
Restore missing native XACT music transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,3 @@ endif()
 set_target_properties(ge PROPERTIES OUTPUT_NAME "GoldenEye")
 
 rexglue_setup_target(ge)
-
-if(WIN32)
-    # Play the restored watch cue without changing ReXGlue's audio path.
-    target_link_libraries(ge PRIVATE winmm)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,3 +39,8 @@ endif()
 set_target_properties(ge PROPERTIES OUTPUT_NAME "GoldenEye")
 
 rexglue_setup_target(ge)
+
+if(WIN32)
+    # Play the restored watch cue without changing ReXGlue's audio path.
+    target_link_libraries(ge PRIVATE winmm)
+endif()

--- a/ge_config.toml
+++ b/ge_config.toml
@@ -267,6 +267,21 @@ name = "ge_ce_death_tune"
 registers = []
 after_instruction = false
 jump_address_on_true = 0x820BFB08
+# The leaked XBLA executable left the two N64 dynamic-music AI opcodes as
+# printf-only stubs. Replace the complete stub blocks and return to the common
+# AI interpreter continuation after advancing its bytecode cursor ourselves.
+[[midasm_hook]]
+address = 0x82135BF0
+name = "ge_music_xtrack_play"
+registers = []
+after_instruction = false
+jump_address = 0x82131ACC
+[[midasm_hook]]
+address = 0x82135C10
+name = "ge_music_xtrack_stop"
+registers = []
+after_instruction = false
+jump_address = 0x82131ACC
 # kill-tune 5.0f relocation @0x8209D88C (read +0x3A8 not +0x3AC)
 [[midasm_hook]]
 address = 0x8209D88C

--- a/src/ge_hooks.cpp
+++ b/src/ge_hooks.cpp
@@ -1162,15 +1162,22 @@ void ge_missing_music_tick(PPCContext& ctx, uint8_t* base) {
   const uint32_t music_state = LD32(base, GE_MUSIC_STATE);
   const uint32_t pending_stage = LD32(base, GE_PENDING_STAGE);
   const uint32_t current_stage = LD32(base, GE_CURRENT_STAGE);
+  const bool title_requested = current_stage == GE_TITLE_STAGE ||
+                               pending_stage == GE_TITLE_STAGE;
 
-  ge_xtrack_tick(ctx, base, player_active);
+  // The outgoing mission's viewport/player pointers can remain valid while
+  // stage 90 is loading.  Do not let that stale player keep an elevator
+  // X-track timer alive behind Mission Select, where its eventual expiry would
+  // restart the previous stage's primary music.
+  if (title_requested && ge_any_xtrack_slot_active()) {
+    REXKRNL_INFO("GEXTRACK clearing slots for Mission Select transition");
+  }
+  ge_xtrack_tick(ctx, base, player_active && !title_requested);
 
   // Some XBLA exits write the boss stage globals directly and never call the
   // N64-style setter. Arm only after an actual player is active in a non-title
   // stage, then observe either current or pending stage becoming title (90).
   // This covers abort, failure, and completion without playing on initial boot.
-  const bool title_requested = current_stage == GE_TITLE_STAGE ||
-                               pending_stage == GE_TITLE_STAGE;
   if (player_active && current_stage != GE_TITLE_STAGE && !title_requested) {
     saw_active_non_title_stage = true;
   }

--- a/src/ge_hooks.cpp
+++ b/src/ge_hooks.cpp
@@ -9,7 +9,9 @@
 // fragment's register/memory effect, tail-invokes the continuation function,
 // and the recompiled source function then returns.
 
+#include <array>
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 
@@ -32,7 +34,6 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
-#include <mmsystem.h>
 #include <shellapi.h>  // ShellExecuteW (WIN32_LEAN_AND_MEAN excludes it)
 #include <string>
 
@@ -900,6 +901,12 @@ constexpr uint32_t GE_SETTINGS_PTR  = 0x83088228u;  // -> settings struct pointe
 constexpr uint32_t GE_SETTINGS_BITS = 0x298u;       // bitflags offset in struct
 constexpr uint32_t GE_PLAYER_PTR    = 0x82F1FA98u;  // -> players[0] (host's Bond)
 constexpr uint32_t GE_BONDVIEW_CUR  = 0x82F1FAACu;  // -> currently-controlled view's player
+constexpr uint32_t GE_MUSIC_STATE   = 0x83066750u;  // XBLA mission-music state (0..6)
+constexpr uint32_t GE_STAGE_MUSIC_ID = 0x8306674Cu; // current stage music-table key
+constexpr uint32_t GE_MUSIC_CUES    = 0x83064DF4u;  // three active native music-cue slots
+constexpr uint32_t GE_PENDING_STAGE = 0x82423DFCu;  // boss g_MainStageNum
+constexpr uint32_t GE_CURRENT_STAGE = 0x82423E00u;  // boss g_StageNum
+constexpr uint32_t GE_TITLE_STAGE   = 90u;
 constexpr uint32_t GE_OFF_WATCH     = 0x2E8u;       // watch status (!=0 -> input disabled)
 constexpr uint32_t GE_OFF_DISABLED  = 0x80u;        // control-disabled flag (cutscene)
 constexpr uint32_t GE_OFF_CAM_X     = 0x254u;       // camera yaw
@@ -915,37 +922,214 @@ enum GESettingFlag {
   GE_SET_LookAhead = 0x80,
 };
 
-// The leaked XBLA build contains the authentic watch cue in music.xwb, but the
-// N64 music script which switched to it was never wired into this version of
-// the game. Supply that missing transition from the same once-per-frame hook
-// which already tracks the watch state. The WAV is decoded from music.xwb entry
-// 33 ("21Goldeneye 64 - 007 Watch Theme") by the optional installer.
-void ge_set_guest_music_volume(PPCContext& source_ctx, uint8_t* base,
-                               uint8_t stored_volume) {
-  // sub_82144AD0 is the game's normal Music-category volume setter. Its input
-  // is the watch slider's 0..100 stored byte converted to the game's scale.
+// The XBLA AI interpreter recognizes opcodes F4/F5, but its handlers only call
+// printf. They are the original music_xtrack_play/music_xtrack_stop commands.
+// Keep their four-slot timing semantics here, then drive the XBLA mission-music
+// state machine (sub_82144C60), which already performs the native XACT lookup,
+// Track 2 playback, and Track 1 cross-fades from music.xsb/music.xwb.
+struct GEXTrackSlot {
+  bool active = false;
+  double minimum_seconds = 0.0;
+  double total_seconds = 0.0;
+};
+
+std::array<GEXTrackSlot, 4> g_xtrack_slots{};
+std::chrono::steady_clock::time_point g_xtrack_last_tick =
+    std::chrono::steady_clock::now();
+bool g_xtrack_had_player = false;
+uint32_t g_xtrack_last_music_state = UINT32_MAX;
+
+bool ge_any_xtrack_slot_active() {
+  for (const GEXTrackSlot& slot : g_xtrack_slots) {
+    if (slot.total_seconds > 0.0 &&
+        (slot.active || slot.minimum_seconds > 0.0)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void ge_stop_native_music_cue(PPCContext& ctx, uint8_t* base,
+                              uint32_t slot) {
+  ctx.r3.u32 = slot;
+  sub_82144A80(ctx, base);
+}
+
+void ge_start_stage_primary_cue(PPCContext& ctx, uint8_t* base) {
+  // This is the same lookup/play sequence used by sub_82144C60 for a normal
+  // 0 -> 1 mission-music transition, kept here because its 2 -> 1 transition
+  // assumes the (missing) fade code merely left Track 1 running silently.
+  ctx.r3.u32 = LD32(base, GE_STAGE_MUSIC_ID);
+  sub_821453C0(ctx, base);
+  const uint32_t cue_id = ctx.r3.u32;
+  if (static_cast<int32_t>(cue_id) < 0) return;
+  ctx.r3.u32 = 0u;
+  ctx.r4.u32 = cue_id;
+  sub_82144BA8(ctx, base);
+}
+
+void ge_start_stage_secondary_cue(PPCContext& ctx, uint8_t* base) {
+  ctx.r3.u32 = LD32(base, GE_STAGE_MUSIC_ID);
+  // sub_82145518 is the stage-specific X-track lookup used by the native
+  // 1 -> 2 and 4 -> 5 transitions. sub_821454C0 is ambience (slot 2), not the
+  // elevator cue.
+  sub_82145518(ctx, base);
+  const uint32_t cue_id = ctx.r3.u32;
+  if (static_cast<int32_t>(cue_id) < 0) return;
+  ctx.r3.u32 = 1u;
+  ctx.r4.u32 = cue_id;
+  sub_82144BA8(ctx, base);
+}
+
+void ge_set_mission_music_state(PPCContext& source_ctx, uint8_t* base,
+                                uint32_t target_state) {
+  const uint32_t old_state = LD32(base, GE_MUSIC_STATE);
+  if (old_state == target_state) return;
+
+  const bool entering_xtrack =
+      (old_state == 1u && target_state == 2u) ||
+      (old_state == 4u && target_state == 5u);
+  const bool leaving_xtrack =
+      (old_state == 2u && target_state == 1u) ||
+      (old_state == 5u && target_state == 4u);
+
+  // Preserve the AI/input caller's registers. The native PPC function uses the
+  // copied guest context and the real guest stack/memory, just like an ordinary
+  // PPC call, and ultimately reaches the game's existing XACT music manager.
   PPCContext call_ctx = source_ctx;
-  call_ctx.r3.u64 = static_cast<uint32_t>(stored_volume) * 128u;
-  sub_82144AD0(call_ctx, base);
+  call_ctx.r3.u32 = target_state;
+  sub_82144C60(call_ctx, base);
+
+  if (entering_xtrack) {
+    // The transition has created Track 2, but its original Track-1 fade call
+    // is a no-op in XBLA. Use the game's well-tested cue-stop wrapper instead.
+    ge_stop_native_music_cue(call_ctx, base, 0u);
+  } else if (leaving_xtrack) {
+    // Its Track-2 fade-out is the same no-op. Stop Track 2, then recreate the
+    // stage's primary cue through the same native lookup/play path used at
+    // mission start. This restarts rather than cross-fades, but stays entirely
+    // within already-exercised game wrappers and avoids unsafe vtable guesses.
+    ge_stop_native_music_cue(call_ctx, base, 1u);
+    ge_start_stage_primary_cue(call_ctx, base);
+  }
+
+  g_xtrack_last_music_state = LD32(base, GE_MUSIC_STATE);
+  REXKRNL_INFO("GEXTRACK state {} -> {} (native cue slot1={:08X})",
+               old_state, LD32(base, GE_MUSIC_STATE),
+               LD32(base, GE_MUSIC_CUES + 4u));
 }
 
-std::wstring ge_watch_theme_path() {
-  wchar_t path[MAX_PATH]{};
-  DWORD length = GetModuleFileNameW(nullptr, path, MAX_PATH);
-  if (!length || length >= MAX_PATH) return {};
-  std::wstring result(path, path + length);
-  size_t slash = result.find_last_of(L"\\/");
-  if (slash != std::wstring::npos) result.resize(slash + 1);
-  else result.clear();
-  result += L"watch_theme.wav";
-  return result;
+void ge_refresh_xtrack_state(PPCContext& ctx, uint8_t* base) {
+  const uint32_t state = LD32(base, GE_MUSIC_STATE);
+
+  const bool supported_mission_state =
+      state == 1u || state == 2u || state == 4u || state == 5u;
+  const bool prior_state_was_xtrack =
+      g_xtrack_last_music_state == 2u || g_xtrack_last_music_state == 5u;
+  const bool state_was_reset_externally =
+      prior_state_was_xtrack && (state == 1u || state == 4u);
+
+  // Mission abort/restart can retain a valid player pointer while the native
+  // music manager tears down and recreates its cues.  Treat an externally
+  // observed X -> normal transition (or any non-mission music state) as the
+  // lifecycle boundary it is. Otherwise Control's 255-second slot survives a
+  // restart and immediately suppresses the next run's primary level theme.
+  if (!supported_mission_state || state_was_reset_externally) {
+    if (ge_any_xtrack_slot_active()) {
+      g_xtrack_slots = {};
+      REXKRNL_INFO("GEXTRACK cleared stale slots at native state {}", state);
+    }
+    g_xtrack_last_music_state = state;
+    return;
+  }
+
+  g_xtrack_last_music_state = state;
+  const bool wants_xtrack = ge_any_xtrack_slot_active();
+
+  // XBLA states mirror the shipped transition table: 1/4 are normal mission
+  // music without/with ambience; 2/5 are their corresponding X-track states.
+  if (wants_xtrack) {
+    if (state == 1u) ge_set_mission_music_state(ctx, base, 2u);
+    else if (state == 4u) ge_set_mission_music_state(ctx, base, 5u);
+  } else {
+    if (state == 2u) ge_set_mission_music_state(ctx, base, 1u);
+    else if (state == 5u) ge_set_mission_music_state(ctx, base, 4u);
+  }
 }
 
-void ge_watch_music_tick(PPCContext& ctx, uint8_t* base) {
-  static bool previous_watch_open = false;
-  static bool theme_playing = false;
+void ge_xtrack_tick(PPCContext& ctx, uint8_t* base, bool player_active) {
+  const auto now = std::chrono::steady_clock::now();
+  double elapsed = std::chrono::duration<double>(now - g_xtrack_last_tick).count();
+  g_xtrack_last_tick = now;
 
-  // Select the active viewport's local player so this also works in multiplayer.
+  if (!player_active) {
+    if (g_xtrack_had_player) {
+      g_xtrack_slots = {};
+      g_xtrack_had_player = false;
+    }
+    g_xtrack_last_music_state = LD32(base, GE_MUSIC_STATE);
+    return;
+  }
+  g_xtrack_had_player = true;
+
+  // The original uses its simulation ClockTimer, so timers do not advance while
+  // paused. Clamp a long host stall as well; loading/alt-tab must not consume an
+  // entire minimum-duration window in one input poll.
+  if (LD32(base, GE_PAUSE_FLAG) != 0u) elapsed = 0.0;
+  if (elapsed > 0.25) elapsed = 0.25;
+
+  if (elapsed > 0.0) {
+    for (GEXTrackSlot& slot : g_xtrack_slots) {
+      if (!slot.active && slot.minimum_seconds <= 0.0) continue;
+      if (slot.minimum_seconds > 0.0) {
+        slot.minimum_seconds -= elapsed;
+        if (slot.minimum_seconds < 0.0) slot.minimum_seconds = 0.0;
+      }
+      if (slot.total_seconds > 0.0) {
+        slot.total_seconds -= elapsed;
+        if (slot.total_seconds <= 0.0) {
+          slot.total_seconds = 0.0;
+          slot.active = false;
+        }
+      }
+    }
+  }
+
+  ge_refresh_xtrack_state(ctx, base);
+}
+
+// The leaked XBLA build contains the authentic watch and Mission Select cues in
+// music.xwb, but several N64 music-script transitions were never wired into
+// this version. Supply those transitions through the game's native XACT music
+// manager from the existing once-per-frame hook; no extracted audio is needed.
+enum class GENativeRestoredMusic {
+  None,
+  MissionSelect,
+  Watch,
+};
+
+GENativeRestoredMusic g_native_restored_music =
+    GENativeRestoredMusic::None;
+
+// Values accepted by sub_82144BA8 are the game's logical music indices, not
+// raw XACT cue indices. The runtime translation table maps 23 -> XACT 11
+// (Mission Select) and 24 -> XACT 32 (watch theme).
+constexpr uint32_t GE_LOGICAL_CUE_MISSION_SELECT = 23u;
+constexpr uint32_t GE_LOGICAL_CUE_WATCH = 24u;
+
+bool ge_start_native_restored_music(PPCContext& source_ctx, uint8_t* base,
+                                    GENativeRestoredMusic kind,
+                                    uint32_t slot, uint32_t logical_cue) {
+  PPCContext call_ctx = source_ctx;
+  call_ctx.r3.u32 = slot;
+  call_ctx.r4.u32 = logical_cue;
+  sub_82144BA8(call_ctx, base);
+  if (LD32(base, GE_MUSIC_CUES + slot * 4u) == 0u) return false;
+  g_native_restored_music = kind;
+  return true;
+}
+
+uint32_t ge_find_active_viewport_player(uint8_t* base) {
   uint32_t player = 0;
   for (int i = 0; i < 4; ++i) {
     uint32_t candidate = LD32(base, GE_PLAYER_PTR + i * 4u);
@@ -954,39 +1138,176 @@ void ge_watch_music_tick(PPCContext& ctx, uint8_t* base) {
       break;
     }
   }
+  return player;
+}
+
+uint32_t ge_find_active_player(uint8_t* base) {
+  uint32_t player = ge_find_active_viewport_player(base);
   if (!player) player = LD32(base, GE_BONDVIEW_CUR);
   if (!player) player = LD32(base, GE_PLAYER_PTR);
+  return player;
+}
+
+void ge_missing_music_tick(PPCContext& ctx, uint8_t* base) {
+  static bool previous_watch_open = false;
+  static bool saw_active_non_title_stage = false;
+  static bool title_music_pending = false;
+  static uint32_t title_settle_frames = 0;
+  static uint32_t watch_saved_music_state = 0;
+  static bool watch_stopped_native_tracks = false;
+  const uint32_t active_viewport_player =
+      ge_find_active_viewport_player(base);
+  const uint32_t player = ge_find_active_player(base);
+  const bool player_active = active_viewport_player != 0;
+  const uint32_t music_state = LD32(base, GE_MUSIC_STATE);
+  const uint32_t pending_stage = LD32(base, GE_PENDING_STAGE);
+  const uint32_t current_stage = LD32(base, GE_CURRENT_STAGE);
+
+  ge_xtrack_tick(ctx, base, player_active);
+
+  // Some XBLA exits write the boss stage globals directly and never call the
+  // N64-style setter. Arm only after an actual player is active in a non-title
+  // stage, then observe either current or pending stage becoming title (90).
+  // This covers abort, failure, and completion without playing on initial boot.
+  const bool title_requested = current_stage == GE_TITLE_STAGE ||
+                               pending_stage == GE_TITLE_STAGE;
+  if (player_active && current_stage != GE_TITLE_STAGE && !title_requested) {
+    saw_active_non_title_stage = true;
+  }
+
+  if (saw_active_non_title_stage && title_requested) {
+    saw_active_non_title_stage = false;
+    title_music_pending = true;
+    title_settle_frames = 0;
+    REXKRNL_INFO("GEMISSINGMUSIC armed Mission Select cue at stage transition current={} pending={}",
+                 current_stage, pending_stage);
+  }
+
+  // pending=90 is written while the outgoing level is still current. Starting
+  // a cue at that point succeeds, but the subsequent title-stage audio reset
+  // destroys it. Wait until stage 90 has been current for a few input ticks so
+  // the title audio system has finished resetting its native cue slots.
+  if (title_music_pending && current_stage == GE_TITLE_STAGE &&
+      ++title_settle_frames >= 3u) {
+    title_music_pending = false;
+    ge_stop_native_music_cue(ctx, base, 0u);
+    ge_stop_native_music_cue(ctx, base, 1u);
+    g_native_restored_music = GENativeRestoredMusic::None;
+    watch_stopped_native_tracks = false;
+    if (ge_start_native_restored_music(
+            ctx, base, GENativeRestoredMusic::MissionSelect, 0u,
+            GE_LOGICAL_CUE_MISSION_SELECT)) {
+      REXKRNL_INFO("GEMISSINGMUSIC started native XACT Mission Select cue at stage transition current={} pending={}",
+                   current_stage, pending_stage);
+    } else {
+      REXKRNL_ERROR("GEMISSINGMUSIC could not play native Mission Select current={} pending={}",
+                    current_stage, pending_stage);
+    }
+  } else if (!title_requested &&
+             (player_active || music_state != 0u) &&
+             g_native_restored_music == GENativeRestoredMusic::MissionSelect) {
+    // A level's own startup replaces slot 0, so relinquish ownership without
+    // stopping the new stage cue.
+    g_native_restored_music = GENativeRestoredMusic::None;
+  }
 
   const bool watch_open = player && LD32(base, GE_PAUSE_FLAG) != 0u &&
                           LD32(base, player + GE_OFF_WATCH) != 0u;
   if (watch_open == previous_watch_open) return;
   previous_watch_open = watch_open;
 
-  const uint32_t settings = LD32(base, GE_SETTINGS_PTR);
   if (watch_open) {
-    const std::wstring path = ge_watch_theme_path();
-    theme_playing = !path.empty() &&
-                    PlaySoundW(path.c_str(), nullptr,
-                               SND_FILENAME | SND_ASYNC | SND_LOOP | SND_NODEFAULT);
-    if (theme_playing) {
-      // Apply a temporary live mute without changing the saved setting.
-      ge_set_guest_music_volume(ctx, base, 0);
-      REXKRNL_INFO("GEWATCHMUSIC started authentic watch cue");
+    watch_saved_music_state = music_state;
+    watch_stopped_native_tracks = true;
+    ge_stop_native_music_cue(ctx, base, 0u);
+    ge_stop_native_music_cue(ctx, base, 1u);
+    g_native_restored_music = GENativeRestoredMusic::None;
+    if (ge_start_native_restored_music(
+            ctx, base, GENativeRestoredMusic::Watch, 0u,
+            GE_LOGICAL_CUE_WATCH)) {
+      REXKRNL_INFO("GEWATCHMUSIC started native XACT watch cue");
     } else {
-      REXKRNL_ERROR("GEWATCHMUSIC could not play watch_theme.wav");
+      REXKRNL_ERROR("GEWATCHMUSIC could not play native watch cue");
     }
   } else {
-    if (theme_playing) {
-      PlaySoundW(nullptr, nullptr, 0);
-      theme_playing = false;
+    const bool had_native_watch =
+        g_native_restored_music == GENativeRestoredMusic::Watch;
+    if (had_native_watch) {
+      ge_stop_native_music_cue(ctx, base, 0u);
+      g_native_restored_music = GENativeRestoredMusic::None;
     }
-    if (settings) {
-      ge_set_guest_music_volume(ctx, base, base[settings + 0x295u]);
+    if (watch_stopped_native_tracks && !title_requested) {
+      PPCContext restore_ctx = ctx;
+      if (watch_saved_music_state == 2u || watch_saved_music_state == 5u ||
+          ge_any_xtrack_slot_active()) {
+        ge_start_stage_secondary_cue(restore_ctx, base);
+        REXKRNL_INFO("GEWATCHMUSIC restored elevator/X-track cue");
+      } else {
+        ge_start_stage_primary_cue(restore_ctx, base);
+        REXKRNL_INFO("GEWATCHMUSIC restored primary level cue");
+      }
     }
-    REXKRNL_INFO("GEWATCHMUSIC stopped watch cue and restored level music");
+    watch_stopped_native_tracks = false;
   }
 }
 }  // namespace
+
+// AI opcode F4: music_xtrack_play(slot, minimum_seconds, total_seconds).
+// The original XBLA block at 0x82135BF0 advances r30 by four bytes and then
+// prints an unimplemented-command message. ge_config.toml skips that whole
+// block, so this hook performs the cursor update as well as the missing action.
+void ge_music_xtrack_play() {
+  PPCContext* ctx;
+  uint8_t* base;
+  getcb(ctx, base);
+
+  const uint32_t command = ctx->r31.u32;
+  const int32_t slot_index = static_cast<int8_t>(base[command + 1u]);
+  const uint8_t minimum_seconds = base[command + 2u];
+  const uint8_t total_seconds = base[command + 3u];
+  ctx->r30.u32 += 4u;
+
+  if (slot_index < 0 || slot_index >= static_cast<int32_t>(g_xtrack_slots.size())) {
+    REXKRNL_ERROR("GEXTRACK ignored F4 with invalid slot {}", slot_index);
+    return;
+  }
+
+  GEXTrackSlot& slot = g_xtrack_slots[static_cast<size_t>(slot_index)];
+  if (!slot.active) {
+    slot.active = true;
+    slot.minimum_seconds = static_cast<double>(minimum_seconds);
+    slot.total_seconds = static_cast<double>(total_seconds);
+    REXKRNL_INFO("GEXTRACK F4 play slot={} minimum={} total={}",
+                 slot_index, minimum_seconds, total_seconds);
+  }
+
+  ge_refresh_xtrack_state(*ctx, base);
+}
+
+// AI opcode F5: music_xtrack_stop(slot). A negative slot means all four slots.
+void ge_music_xtrack_stop() {
+  PPCContext* ctx;
+  uint8_t* base;
+  getcb(ctx, base);
+
+  const uint32_t command = ctx->r31.u32;
+  const int32_t slot_index = static_cast<int8_t>(base[command + 1u]);
+  ctx->r30.u32 += 2u;
+
+  if (slot_index < 0) {
+    g_xtrack_slots = {};
+    REXKRNL_INFO("GEXTRACK F5 stopped all slots");
+  } else if (slot_index < static_cast<int32_t>(g_xtrack_slots.size())) {
+    // Match the original semantics: stopping clears the active flag but leaves
+    // the minimum-duration timer running before the main track may return.
+    g_xtrack_slots[static_cast<size_t>(slot_index)].active = false;
+    REXKRNL_INFO("GEXTRACK F5 stop slot={}", slot_index);
+  } else {
+    REXKRNL_ERROR("GEXTRACK ignored F5 with invalid slot {}", slot_index);
+  }
+
+  ge_refresh_xtrack_state(*ctx, base);
+}
 
 void ge_mouse_camera(uint8_t* base) {
   // Persistent state (= GoldeneyeGame member vars in xenia).
@@ -1267,9 +1588,9 @@ void ge_inject_keyboard(PPCRegister& /*r11*/) {
     REXKRNL_INFO("GECE community data bug-fixes applied");
   }
 
-  // Restore the missing XBLA watch-theme transition regardless of whether
-  // keyboard or mouse-look support is enabled.
-  ge_watch_music_tick(*ctx, base);
+  // Restore missing XBLA music transitions regardless of whether keyboard or
+  // mouse-look support is enabled.
+  ge_missing_music_tick(*ctx, base);
 
   // Rebind capture: the menu is listening for a key to bind. Swallow ALL slot-0
   // controller input (buttons, triggers, both sticks) so the key/button being

--- a/src/ge_hooks.cpp
+++ b/src/ge_hooks.cpp
@@ -32,6 +32,7 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+#include <mmsystem.h>
 #include <shellapi.h>  // ShellExecuteW (WIN32_LEAN_AND_MEAN excludes it)
 #include <string>
 
@@ -913,6 +914,78 @@ enum GESettingFlag {
   GE_SET_AutoAim   = 0x10,
   GE_SET_LookAhead = 0x80,
 };
+
+// The leaked XBLA build contains the authentic watch cue in music.xwb, but the
+// N64 music script which switched to it was never wired into this version of
+// the game. Supply that missing transition from the same once-per-frame hook
+// which already tracks the watch state. The WAV is decoded from music.xwb entry
+// 33 ("21Goldeneye 64 - 007 Watch Theme") by the optional installer.
+void ge_set_guest_music_volume(PPCContext& source_ctx, uint8_t* base,
+                               uint8_t stored_volume) {
+  // sub_82144AD0 is the game's normal Music-category volume setter. Its input
+  // is the watch slider's 0..100 stored byte converted to the game's scale.
+  PPCContext call_ctx = source_ctx;
+  call_ctx.r3.u64 = static_cast<uint32_t>(stored_volume) * 128u;
+  sub_82144AD0(call_ctx, base);
+}
+
+std::wstring ge_watch_theme_path() {
+  wchar_t path[MAX_PATH]{};
+  DWORD length = GetModuleFileNameW(nullptr, path, MAX_PATH);
+  if (!length || length >= MAX_PATH) return {};
+  std::wstring result(path, path + length);
+  size_t slash = result.find_last_of(L"\\/");
+  if (slash != std::wstring::npos) result.resize(slash + 1);
+  else result.clear();
+  result += L"watch_theme.wav";
+  return result;
+}
+
+void ge_watch_music_tick(PPCContext& ctx, uint8_t* base) {
+  static bool previous_watch_open = false;
+  static bool theme_playing = false;
+
+  // Select the active viewport's local player so this also works in multiplayer.
+  uint32_t player = 0;
+  for (int i = 0; i < 4; ++i) {
+    uint32_t candidate = LD32(base, GE_PLAYER_PTR + i * 4u);
+    if (candidate && LD32(base, candidate + 0x904u) == 0u) {
+      player = candidate;
+      break;
+    }
+  }
+  if (!player) player = LD32(base, GE_BONDVIEW_CUR);
+  if (!player) player = LD32(base, GE_PLAYER_PTR);
+
+  const bool watch_open = player && LD32(base, GE_PAUSE_FLAG) != 0u &&
+                          LD32(base, player + GE_OFF_WATCH) != 0u;
+  if (watch_open == previous_watch_open) return;
+  previous_watch_open = watch_open;
+
+  const uint32_t settings = LD32(base, GE_SETTINGS_PTR);
+  if (watch_open) {
+    const std::wstring path = ge_watch_theme_path();
+    theme_playing = !path.empty() &&
+                    PlaySoundW(path.c_str(), nullptr,
+                               SND_FILENAME | SND_ASYNC | SND_LOOP | SND_NODEFAULT);
+    if (theme_playing) {
+      // Apply a temporary live mute without changing the saved setting.
+      ge_set_guest_music_volume(ctx, base, 0);
+      REXKRNL_INFO("GEWATCHMUSIC started authentic watch cue");
+    } else {
+      REXKRNL_ERROR("GEWATCHMUSIC could not play watch_theme.wav");
+    }
+  } else {
+    if (theme_playing) {
+      PlaySoundW(nullptr, nullptr, 0);
+      theme_playing = false;
+    }
+    if (settings) {
+      ge_set_guest_music_volume(ctx, base, base[settings + 0x295u]);
+    }
+    REXKRNL_INFO("GEWATCHMUSIC stopped watch cue and restored level music");
+  }
+}
 }  // namespace
 
 void ge_mouse_camera(uint8_t* base) {
@@ -1182,7 +1255,7 @@ void ge_mouse_camera(uint8_t* base);  // defined above
 void ge_apply_ce_data_patches(uint8_t* base);  // ge_ce_patches.cpp
 
 void ge_inject_keyboard(PPCRegister& /*r11*/) {
-  PPCContext* ctx; uint8_t* base; getcb(ctx, base); (void)ctx;
+  PPCContext* ctx; uint8_t* base; getcb(ctx, base);
 
   // Apply BeanTools community DATA bug-fixes once, before any level loads its
   // setup/fog/BG data. The data segment is live in guest RAM by the first input
@@ -1193,6 +1266,10 @@ void ge_inject_keyboard(PPCRegister& /*r11*/) {
     ge_apply_ce_data_patches(base);
     REXKRNL_INFO("GECE community data bug-fixes applied");
   }
+
+  // Restore the missing XBLA watch-theme transition regardless of whether
+  // keyboard or mouse-look support is enabled.
+  ge_watch_music_tick(*ctx, base);
 
   // Rebind capture: the menu is listening for a key to bind. Swallow ALL slot-0
   // controller input (buttons, triggers, both sticks) so the key/button being


### PR DESCRIPTION
## What changed  Fixes #83 and also restores two related music systems that were missing from the leaked XBLA build:  - **Watch/pause music:** opening the watch starts the authentic watch cue through the game's existing XACT music manager; closing it restores whichever native stage cue was active. - **Control and Caverns elevator music:** implements the N64 `music_xtrack_play` / `music_xtrack_stop` AI commands (opcodes F4/F5), including their four timed slots and the existing XBLA mission-music state machine. - **Post-mission menu music:** restores Mission Select music after abort, failure, or completion, delayed until the title-stage audio reset has finished. Outgoing elevator timers are cleared as soon as stage 90 is requested, so stale level music cannot replace Mission Select several minutes later. - **Correct restoration:** closing the watch inside an elevator restores the elevator/X-track cue; closing it elsewhere restores the primary level cue. Leaving and re-entering an elevator continues to switch correctly.  Everything now plays from the user's existing `music.xwb` / `music.xsb` / `music.xgs` through native XACT. No extracted WAV, installer, bundled game audio, `PlaySoundW`, or `winmm` dependency is used.  ## Root cause  The audio itself was present, but several transitions were unfinished:  1. XBLA's F4/F5 AI handlers only printed an unimplemented-command message, so level scripts could not request or stop X-tracks such as the elevator music. 2. The watch and post-mission paths never requested their existing music-bank entries. 3. The low-level cue-start function accepts the game's **logical music IDs**, not raw XACT cue indices. Runtime mapping established:    - logical 23 -> XACT cue 11: Mission Select    - logical 24 -> XACT cue 32: Watch Theme 4. An early Mission Select request was destroyed by the subsequent title-stage audio reset, so playback is armed during the stage request and started after stage 90 settles. 5. Restoring elevator music requires the stage-specific X-track lookup (`sub_82145518`); the nearby lookup previously tested was ambience, not the elevator cue.
6. The outgoing player pointer remains valid briefly during an abort. Without treating the stage-90 request as an immediate X-track lifecycle boundary, Control's 255-second elevator slot continued ticking behind Mission Select and restarted the stale Control level cue when it expired.  ## Implementation  - Hooks the complete F4/F5 printf-only blocks and advances the AI bytecode cursor before returning to the common interpreter continuation. - Tracks the original four X-track slots and their minimum/total durations using a pause-aware timer. - Drives the existing mission-music states 1/2 and 4/5 and uses the game's own XACT lookup/start/stop wrappers. - Clears X-track slots immediately when current or pending stage becomes Mission Select, even while the outgoing viewport player pointer is still valid. - Tracks watch transitions from the existing once-per-frame input hook. - Starts the watch and Mission Select cues using the game's logical-to-XACT translation path. - Stops and reconstructs the appropriate native stage slot when switching between primary and X-track music.  ## Validation  Tested in a Windows 1.2.4 build using the original game music banks:  - Watch theme starts and stops correctly during normal level play. - Watch theme starts inside Control's elevator and closing the watch immediately restores elevator music. - Exiting the elevator restores Control's primary level music; re-entering restores elevator music. - Caverns' corresponding elevator/X-track transition works. - Mission Select music starts after mission abort and remains active.
- Regression tested by aborting Control while its elevator X-track was active and remaining at Mission Select beyond the full 255-second slot duration; no stale Control music returns. - Runtime logs show only native XACT cue creation and no external-audio fallback. - ReXGlue code generation succeeds. - The modified `ge_hooks.cpp` translation unit compiles successfully. - Full compatible-runtime build completes and was exercised in game. - `git diff --check` passes.  ## Note on transitions  The XBLA fade path used by these missing transitions is itself ineffective. This patch uses the game's proven cue stop/start wrappers, so elevator transitions are clean hard switches rather than cross-fades. This avoids unsafe XACT vtable calls while keeping all playback and volume handling native.  No ROM, XEX, XWB/XSB/XGS bank, extracted audio, or other copyrighted game asset is included.